### PR TITLE
refactor: refactor bad smell SizeReplaceableByIsEmpty

### DIFF
--- a/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/ModificationAnalyzerFactory.java
+++ b/src/main/java/jetbrains/buildServer/investigationsAutoAssigner/processing/ModificationAnalyzerFactory.java
@@ -73,7 +73,7 @@ public class ModificationAnalyzerFactory {
     @Nullable
     public User getOnlyCommitter(Set<String> usersToIgnore) throws HeuristicNotApplicableException {
       Collection<SUser> committers = myVcsChange.getCommitters();
-      if (committers.size() == 0) {
+      if (committers.isEmpty()) {
         throw new HeuristicNotApplicableException(
           "committer \"" + myVcsChange.getUserName() + "\" does not have corresponding TeamCity user");
       }
@@ -118,7 +118,7 @@ public class ModificationAnalyzerFactory {
   private static List<String> getPatterns(@NotNull final String filePath) {
     final List<String> parts = new ArrayList<>();
     String withoutExtension = FileUtil.getNameWithoutExtension(new File(filePath));
-    if (withoutExtension.length() == 0) {
+    if (withoutExtension.isEmpty()) {
       return Collections.emptyList();
     }
     parts.add(withoutExtension);


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## SizeReplaceableByIsEmpty
Checking if a something is empty should be done by `Object#isEmpty` instead of `Object.size==0`
<!-- fingerprint:Qodana-teamcity-investigations-auto-assigner-SizeReplaceableByIsEmpty-f33ce6fcc98ba58a97962fe9073f7c60d3e3f57e-sl:121-el:0-sc:9-ec:0-co:4429-cl:30 -->
<!-- fingerprint:Qodana-teamcity-investigations-auto-assigner-SizeReplaceableByIsEmpty-f33ce6fcc98ba58a97962fe9073f7c60d3e3f57e-sl:76-el:0-sc:11-ec:0-co:2712-cl:22 -->
# Repairing Code Style Issues
* SizeReplaceableByIsEmpty (2)
